### PR TITLE
Supporting nvidia localization for nav2 following REP 105 - Coordinat…

### DIFF
--- a/isaac_ros_occupancy_grid_localizer/config/occupancy_grid_localizer_node.yaml
+++ b/isaac_ros_occupancy_grid_localizer/config/occupancy_grid_localizer_node.yaml
@@ -150,7 +150,7 @@ components:
     occupancy_2d_map_provider: occupancy_2d_map_provider/occupancy_2d_map_provider
     robot_radius: 0.25
     max_beam_error: 0.5
-    max_output_error: 0.35
+    max_output_error: 0.40 # 0.35
     min_output_error: 0.22
     num_beams_gpu: 512
     batch_size: 512
@@ -158,7 +158,7 @@ components:
     patch_size: [512, 512]
     out_of_range_threshold: 100.0
     invalid_range_threshold: 0.0
-    min_scan_fov_degrees: 270.0
+    min_scan_fov_degrees: 100.0 # 270.0
     use_closest_beam: true
 ---
 name: broadcaster

--- a/isaac_ros_occupancy_grid_localizer/include/isaac_ros_occupancy_grid_localizer/occupancy_grid_localizer_node.hpp
+++ b/isaac_ros_occupancy_grid_localizer/include/isaac_ros_occupancy_grid_localizer/occupancy_grid_localizer_node.hpp
@@ -34,6 +34,8 @@
 #include "tf2_ros/transform_listener.h"
 #include "tf2_ros/buffer.h"
 
+#include "tf2_ros/transform_broadcaster.h"
+
 namespace nvidia
 {
 namespace isaac_ros
@@ -129,6 +131,8 @@ private:
   unsigned int map_png_height_;
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
   std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
+
+  std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
 };
 
 }  // namespace occupancy_grid_localizer

--- a/isaac_ros_occupancy_grid_localizer/launch/isaac_ros_occupancy_grid_localizer_nav2.launch.py
+++ b/isaac_ros_occupancy_grid_localizer/launch/isaac_ros_occupancy_grid_localizer_nav2.launch.py
@@ -84,13 +84,17 @@ def generate_launch_description():
         parameters=[LaunchConfiguration('map_file'), {
             'loc_result_frame': 'map',
             'map_yaml_path': LaunchConfiguration('map_file'),
+            'use_sim_time': LaunchConfiguration('use_sim_time'),
         }],
         remappings=[('localization_result', '/initialpose')])
 
     laserscan_to_flatscan_node = ComposableNode(
         package='isaac_ros_pointcloud_utils',
         plugin='nvidia::isaac_ros::pointcloud_utils::LaserScantoFlatScanNode',
-        name='laserscan_to_flatscan')
+        name='laserscan_to_flatscan',
+        parameters=[{'use_sim_time': LaunchConfiguration('use_sim_time')}],
+        remappings=[('flatscan', '/flatscan_localization')]
+        )
 
     occupancy_grid_localizer_container = ComposableNodeContainer(
         package='rclcpp_components',

--- a/isaac_ros_occupancy_grid_localizer/launch/isaac_ros_occupancy_grid_localizer_nav2.launch.py
+++ b/isaac_ros_occupancy_grid_localizer/launch/isaac_ros_occupancy_grid_localizer_nav2.launch.py
@@ -33,7 +33,8 @@ def generate_launch_description():
     map_file_arg = DeclareLaunchArgument(
         'map_file', default_value=os.path.join(
             get_package_share_directory(
-                'isaac_ros_occupancy_grid_localizer'), 'maps', 'isaac_sim.yaml'),
+                # 'isaac_ros_occupancy_grid_localizer'), 'maps', 'isaac_sim.yaml'),
+                'carter_navigation'), 'maps', 'carter_warehouse_navigation.yaml'),
         description='Full path to map file to load')
     params_file_arg = DeclareLaunchArgument(
         'params_file', default_value=os.path.join(
@@ -122,7 +123,7 @@ def generate_launch_description():
         package='tf2_ros', executable='static_transform_publisher',
         parameters=[{'use_sim_time': LaunchConfiguration('use_sim_time')}],
         output='screen',
-        arguments=['0.0', '0.0', '0.0', '0.0', '0.0', '0.0', 'base_link',
+        arguments=['0.2', '0.0', '0.2', '0.0', '0.0', '0.0', 'base_link', # Original: arguments=['0.0', '0.0', '0.0', '0.0', '0.0', '0.0', 'base_link',
                    'lidar_frame'])
 
     return LaunchDescription([

--- a/isaac_ros_occupancy_grid_localizer/launch/isaac_ros_occupancy_grid_localizer_quickstart.launch.py
+++ b/isaac_ros_occupancy_grid_localizer/launch/isaac_ros_occupancy_grid_localizer_quickstart.launch.py
@@ -30,7 +30,7 @@ def generate_launch_description():
 
     lifecycle_nodes = ['map_server']
     map_yaml_path_dir = os.path.join(
-        get_package_share_directory('isaac_ros_occupancy_grid_localizer'), 'maps', 'map.yaml')
+        get_package_share_directory('isaac_ros_occupancy_grid_localizer'), 'maps', 'isaac.yaml')
 
     occupancy_grid_localizer_node = ComposableNode(
         package='isaac_ros_occupancy_grid_localizer',
@@ -39,6 +39,7 @@ def generate_launch_description():
         parameters=[map_yaml_path_dir, {
             'loc_result_frame': 'map',
             'map_yaml_path': map_yaml_path_dir,
+            'use_sim_time': True
         }])
 
     occupancy_grid_localizer_container = ComposableNodeContainer(
@@ -57,7 +58,7 @@ def generate_launch_description():
     baselink_lidar_publisher = Node(
         package='tf2_ros', executable='static_transform_publisher',
         output='screen',
-        arguments=['0.0', '0.0', '0.0', '0.0', '0.0', '0.0', 'base_link',
+        arguments=['0.0', '0.0', '0.0', '0.0', '0.0', '0.0', 'front_3d_lidar',
                    'lidar_frame'])
 
     load_nodes = GroupAction(

--- a/isaac_ros_occupancy_grid_localizer/src/occupancy_grid_localizer_node.cpp
+++ b/isaac_ros_occupancy_grid_localizer/src/occupancy_grid_localizer_node.cpp
@@ -30,6 +30,7 @@ namespace fs = std::filesystem;
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
+#include "tf2_ros/transform_broadcaster.h"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -203,6 +204,8 @@ OccupancyGridLocalizerNode::OccupancyGridLocalizerNode(const rclcpp::NodeOptions
     this->create_publisher<isaac_ros_pointcloud_interfaces::msg::FlatScan>(
     INPUT_TOPIC_NAME_FLATSCAN, 10);
   startNitrosNode();
+
+  tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(this);
 }
 
 void OccupancyGridLocalizerNode::GePngImageHeight(
@@ -378,6 +381,60 @@ void OccupancyGridLocalizerNode::LocResultNitrosSubCallback(
   // The ros_pose_isaac_transform transformation matrix is
   // applied so that the published output conforms to ROS map conventions
   *pose_handle = ros_map_origin_transform * ros_pose_isaac_transform * (*pose_handle);
+
+  geometry_msgs::msg::TransformStamped odom_to_base_link_transform;
+
+  try
+  {
+    odom_to_base_link_transform = tf_buffer_->lookupTransform("odom", kBaseLinkFrameName, tf2::TimePointZero);
+  }
+  catch (const tf2::TransformException & ex)
+  {
+    RCLCPP_INFO(
+      this->get_logger(), "Could not transform %s to %s: %s. Using Identity transform",
+      "odom", kBaseLinkFrameName, ex.what());
+  }
+
+  // map_to_base_link_transform = *pose_handle
+  auto map_to_base_link_transform = *pose_handle;
+
+
+
+  auto baselink_to_odom_transform_isaac = ::isaac::Pose3d{
+    ::isaac::SO3d::FromQuaternion(
+      ::isaac::Quaterniond{ odom_to_base_link_transform.transform.rotation.w,
+      odom_to_base_link_transform.transform.rotation.x,
+      odom_to_base_link_transform.transform.rotation.y,
+      odom_to_base_link_transform.transform.rotation.z}),
+    ::isaac::Vector3d(
+      odom_to_base_link_transform.transform.translation.x,
+      odom_to_base_link_transform.transform.translation.y,
+      odom_to_base_link_transform.transform.translation.z)
+  };
+
+  auto baselink_to_odom_transform = baselink_to_odom_transform_isaac.inverse();
+
+  auto base_link_to_map_transform = map_to_base_link_transform.inverse();
+
+  auto map_to_odom_transform = map_to_base_link_transform  * baselink_to_odom_transform;
+
+
+  geometry_msgs::msg::TransformStamped transform;
+  transform.header.stamp = this->get_clock()->now();
+  transform.header.frame_id = "map";
+  transform.child_frame_id = "odom";
+
+  transform.transform.translation.x = map_to_odom_transform.translation.x();
+  transform.transform.translation.y = map_to_odom_transform.translation.y();
+  transform.transform.translation.z = map_to_odom_transform.translation.z();
+
+  auto q = map_to_odom_transform.rotation.quaternion();
+  transform.transform.rotation.x = q.x();
+  transform.transform.rotation.y = q.y();
+  transform.transform.rotation.z = q.z();
+  transform.transform.rotation.w = q.w();
+
+  tf_broadcaster_->sendTransform(transform);
 }
 
 void OccupancyGridLocalizerNode::preLoadGraphCallback()

--- a/isaac_ros_occupancy_grid_localizer/src/occupancy_grid_localizer_node.cpp
+++ b/isaac_ros_occupancy_grid_localizer/src/occupancy_grid_localizer_node.cpp
@@ -140,14 +140,14 @@ OccupancyGridLocalizerNode::OccupancyGridLocalizerNode(const rclcpp::NodeOptions
   use_gxf_map_convention_(declare_parameter<bool>("use_gxf_map_convention", false)),
   robot_radius_(declare_parameter<double>("robot_radius", 0.25)),
   max_beam_error_(declare_parameter<double>("max_beam_error", 0.5)),
-  max_output_error_(declare_parameter<double>("max_output_error", 0.35)),
+  max_output_error_(declare_parameter<double>("max_output_error", 0.40 /*0.35*/)),
   min_output_error_(declare_parameter<double>("min_output_error", 0.22)),
   num_beams_gpu_(declare_parameter<int>("num_beams_gpu", 512)),
   batch_size_(declare_parameter<int>("batch_size", 512)),
   sample_distance_(declare_parameter<double>("sample_distance", 0.1)),
   out_of_range_threshold_(declare_parameter<double>("out_of_range_threshold", 100.0)),
   invalid_range_threshold_(declare_parameter<double>("invalid_range_threshold", 0.0)),
-  min_scan_fov_degrees_(declare_parameter<double>("min_scan_fov_degrees", 270.0)),
+  min_scan_fov_degrees_(declare_parameter<double>("min_scan_fov_degrees", 100.0 /*270.0*/)),
   use_closest_beam_(declare_parameter<bool>("use_closest_beam", true))
 {
   RCLCPP_DEBUG(get_logger(), "[OccupancyGridLocalizerNode] Constructor");

--- a/isaac_ros_pointcloud_utils/src/laserscan_to_flatscan_node.cpp
+++ b/isaac_ros_pointcloud_utils/src/laserscan_to_flatscan_node.cpp
@@ -37,7 +37,7 @@ LaserScantoFlatScanNode::LaserScantoFlatScanNode(rclcpp::NodeOptions options)
 : Node("laserscan_to_flatscan", options.use_intra_process_comms(true)),
   // topics
   laserscan_sub_(create_subscription<sensor_msgs::msg::LaserScan>(
-      "/scan", 10, std::bind(&LaserScantoFlatScanNode::LaserScanCallback,
+      "/scan", rclcpp::QoS(10).best_effort(), std::bind(&LaserScantoFlatScanNode::LaserScanCallback,
       this, std::placeholders::_1))),
   flatscan_pub_(
     create_publisher<isaac_ros_pointcloud_interfaces::msg::FlatScan>(


### PR DESCRIPTION
This pull request is initially for discussion proposes. 
The current implementation of isaac_ros_map_localization does not publish the output transform into tf following the REP 105.

Instead it publishes robot position in the /localization_result topic (using the global /map reference frame).

To support nav2 it is required to publish the /map -> /odom transform via a tf2 broadcaster.


Supporting nvidia localization for nav2 following REP 105 - Coordinate Frames for Mobile Platforms.