### PR TITLE
(v2.0.0) Supporting nvidia localization for nav2 following REP 105

### DIFF
--- a/isaac_ros_occupancy_grid_localizer/config/occupancy_grid_localizer_node.yaml
+++ b/isaac_ros_occupancy_grid_localizer/config/occupancy_grid_localizer_node.yaml
@@ -159,7 +159,7 @@ components:
     patch_size: [512, 512]
     out_of_range_threshold: 100.0
     invalid_range_threshold: 0.0
-    min_scan_fov_degrees: 270.0
+    min_scan_fov_degrees: 100.0 # 270.0
     use_closest_beam: true
 ---
 name: broadcaster

--- a/isaac_ros_occupancy_grid_localizer/include/isaac_ros_occupancy_grid_localizer/occupancy_grid_localizer_node.hpp
+++ b/isaac_ros_occupancy_grid_localizer/include/isaac_ros_occupancy_grid_localizer/occupancy_grid_localizer_node.hpp
@@ -34,6 +34,8 @@
 #include "tf2_ros/transform_listener.h"
 #include "tf2_ros/buffer.h"
 
+#include "tf2_ros/transform_broadcaster.h"
+
 namespace nvidia
 {
 namespace isaac_ros
@@ -129,6 +131,8 @@ private:
   unsigned int map_png_height_;
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
   std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
+
+  std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
 };
 
 }  // namespace occupancy_grid_localizer

--- a/isaac_ros_occupancy_grid_localizer/launch/isaac_ros_occupancy_grid_localizer_quickstart.launch.py
+++ b/isaac_ros_occupancy_grid_localizer/launch/isaac_ros_occupancy_grid_localizer_quickstart.launch.py
@@ -39,6 +39,7 @@ def generate_launch_description():
         parameters=[map_yaml_path_dir, {
             'loc_result_frame': 'map',
             'map_yaml_path': map_yaml_path_dir,
+            'use_sim_time': True
         }])
 
     occupancy_grid_localizer_container = ComposableNodeContainer(

--- a/isaac_ros_pointcloud_utils/launch/isaac_ros_pointcloud_to_flatscan.launch.py
+++ b/isaac_ros_pointcloud_utils/launch/isaac_ros_pointcloud_to_flatscan.launch.py
@@ -24,7 +24,8 @@ def generate_launch_description():
     pointcloud_to_flatscan_node = ComposableNode(
         package='isaac_ros_pointcloud_utils',
         plugin='nvidia::isaac_ros::pointcloud_utils::PointCloudToFlatScanNode',
-        name='pointcloud_to_flatscan')
+        name='pointcloud_to_flatscan',
+        parameters=[{'flatscan_frame': 'lidar'}])
 
     pointcloud_to_flatscan_container = ComposableNodeContainer(
         package='rclcpp_components',

--- a/isaac_ros_pointcloud_utils/src/flatscan_to_laserscan_node.cpp
+++ b/isaac_ros_pointcloud_utils/src/flatscan_to_laserscan_node.cpp
@@ -39,11 +39,11 @@ FlatScantoLaserScanNode::FlatScantoLaserScanNode(rclcpp::NodeOptions options)
   max_range_fallback_(declare_parameter<double>("max_range_fallback", 200.0)),
   // topics
   flatscan_sub_(create_subscription<isaac_ros_pointcloud_interfaces::msg::FlatScan>(
-      "flatscan", 10, std::bind(&FlatScantoLaserScanNode::FlatScanCallback, this,
+      "/flatscan", 10, std::bind(&FlatScantoLaserScanNode::FlatScanCallback, this,
       std::placeholders::_1))),
   laserscan_pub_(
     create_publisher<sensor_msgs::msg::LaserScan>(
-      "scan", rclcpp::QoS(10)))
+      "/scan", rclcpp::QoS(10)))
 {}
 
 void FlatScantoLaserScanNode::FlatScanCallback(

--- a/isaac_ros_pointcloud_utils/src/laserscan_to_flatscan_node.cpp
+++ b/isaac_ros_pointcloud_utils/src/laserscan_to_flatscan_node.cpp
@@ -37,11 +37,11 @@ LaserScantoFlatScanNode::LaserScantoFlatScanNode(rclcpp::NodeOptions options)
 : Node("laserscan_to_flatscan", options.use_intra_process_comms(true)),
   // topics
   laserscan_sub_(create_subscription<sensor_msgs::msg::LaserScan>(
-      "scan", 10, std::bind(&LaserScantoFlatScanNode::LaserScanCallback,
+      "/scan", rclcpp::QoS(10).best_effort(), std::bind(&LaserScantoFlatScanNode::LaserScanCallback,
       this, std::placeholders::_1))),
   flatscan_pub_(
     create_publisher<isaac_ros_pointcloud_interfaces::msg::FlatScan>(
-      "flatscan", rclcpp::QoS(10)))
+      "/flatscan", rclcpp::QoS(10)))
 {
 }
 


### PR DESCRIPTION
The current implementation of isaac_ros_map_localization does not publish the output transform into tf following the REP 105.

"The goal of a localization system is keep a continous track of the position of the robot (not just finding some initial position - amcl is itself able to converge by its own even without any initial position)"  (answering https://github.com/NVIDIA-ISAAC-ROS/isaac_ros_map_localization/pull/22#issuecomment-1791695390)

The previous implementation publishes the robot position in the /localization_result topic (using the global /map reference frame) but nothing is published in /tf according (to REP 105)

To support nav2 it is required to publish the /map -> /odom transform via a tf2 broadcaster.
From my point of view, without these proposed changes we could not claim that this package is integrated with nav2.

